### PR TITLE
Fix mobile nav wrapping in papers list

### DIFF
--- a/layouts/papers/list.html
+++ b/layouts/papers/list.html
@@ -122,7 +122,7 @@
       </div>
       <!-- Navigation Menu -->
       <nav>
-        <ul class="flex space-x-6">
+        <ul class="flex flex-wrap gap-x-6 gap-y-2 text-center sm:flex-nowrap">
           <li>
             <a href="/papers/" class="hover:text-pink-600 {{ if eq .Page.RelPermalink "/papers/" }}active-link{{ end }}">EXPLORE CORE</a>
           </li>

--- a/public/papers/index.html
+++ b/public/papers/index.html
@@ -122,7 +122,7 @@
       </div>
       
       <nav>
-        <ul class="flex space-x-6">
+        <ul class="flex flex-wrap gap-x-6 gap-y-2 text-center sm:flex-nowrap">
           <li>
             <a href="/papers/" class="hover:text-pink-600 active-link">EXPLORE CORE</a>
           </li>


### PR DESCRIPTION
## Summary
- allow wrapping navigation menu items on small screens
- update generated `public` HTML for papers list

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf2c4bff48324a1bf388b2d911cf6